### PR TITLE
loading and pulling rows of a text based map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+# VSCode files
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ crashlytics-build.properties
 
 # VSCode files
 .vscode/
+
+# Bash scripts
+ignore.sh

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7382fad93f4f89445bfc9da48f40f964
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/BlueDemoUnit.prefab
+++ b/Assets/Prefabs/BlueDemoUnit.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &317296598701736202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7935256465526183140}
+  - component: {fileID: 6019897655725274287}
+  m_Layer: 0
+  m_Name: BlueDemoUnit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7935256465526183140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317296598701736202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6019897655725274287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 317296598701736202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2d0fe5ea84ce254e86f8e7810c49e79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Initial: 80
+  Player: 49

--- a/Assets/Prefabs/BlueDemoUnit.prefab.meta
+++ b/Assets/Prefabs/BlueDemoUnit.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: aa9ee989d493c9a40972b403e35b358e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/EmptyTile.prefab
+++ b/Assets/Prefabs/EmptyTile.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2300288467195036540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6840160693988051681}
+  - component: {fileID: 7930735171800580672}
+  m_Layer: 0
+  m_Name: EmptyTile
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6840160693988051681
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2300288467195036540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7930735171800580672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2300288467195036540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48b1727c0294b164cb4f5dee5a904e7c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/EmptyTile.prefab.meta
+++ b/Assets/Prefabs/EmptyTile.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7cb986b37623c749abd6d2e4f1fcb5c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/RedDemoUnit.prefab
+++ b/Assets/Prefabs/RedDemoUnit.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9113439969275760816
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1441577910674031966}
+  - component: {fileID: 2996243726277272853}
+  m_Layer: 0
+  m_Name: RedDemoUnit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1441577910674031966
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9113439969275760816}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2996243726277272853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9113439969275760816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2d0fe5ea84ce254e86f8e7810c49e79, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Initial: 80
+  Player: 50

--- a/Assets/Prefabs/RedDemoUnit.prefab.meta
+++ b/Assets/Prefabs/RedDemoUnit.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8af795472c6824c428b48b12b806aa2b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -150,8 +150,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8777f4488918d4e40a973994cf34ffea, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Width: 3
-  Height: 3
+  StartWidth: 3
+  StartHeight: 3
   HorizontalBuffer: 1
   VerticalBuffer: 1
   UnitsToAdd:

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -50,12 +50,11 @@ LightmapSettings:
     m_BounceScale: 1
     m_IndirectOutputScale: 1
     m_AlbedoBoost: 1
-    m_TemporalCoherenceThreshold: 1
     m_EnvironmentLightingMode: 0
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 10
+    serializedVersion: 12
     m_Resolution: 2
     m_BakeResolution: 40
     m_AtlasSize: 1024
@@ -63,6 +62,7 @@ LightmapSettings:
     m_AOMaxDistance: 1
     m_CompAOExponent: 1
     m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
     m_Padding: 2
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
@@ -77,10 +77,16 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
     m_PVRFilterTypeDirect: 0
     m_PVRFilterTypeIndirect: 0
     m_PVRFilterTypeAO: 0
-    m_PVRFilteringMode: 1
+    m_PVREnvironmentMIS: 0
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
@@ -88,7 +94,9 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -113,12 +121,71 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &414157293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 414157295}
+  - component: {fileID: 414157294}
+  m_Layer: 0
+  m_Name: MapController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &414157294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 414157293}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8777f4488918d4e40a973994cf34ffea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Width: 3
+  Height: 3
+  HorizontalBuffer: 1
+  VerticalBuffer: 1
+  UnitsToAdd:
+    Units:
+    - {fileID: 6019897655725274287, guid: aa9ee989d493c9a40972b403e35b358e, type: 3}
+    - {fileID: 2996243726277272853, guid: 8af795472c6824c428b48b12b806aa2b, type: 3}
+    Points:
+    - X: 2
+      Y: 3
+    - X: 2
+      Y: 1
+  EmptyTilePrefab: {fileID: 2300288467195036540, guid: b7cb986b37623c749abd6d2e4f1fcb5c,
+    type: 3}
+--- !u!4 &414157295
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 414157293}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
   m_Component:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
@@ -133,20 +200,28 @@ GameObject:
 --- !u!81 &519420029
 AudioListener:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 2
   m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -176,8 +251,9 @@ Camera:
 --- !u!4 &519420032
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7191afe8d8d107f44b31d2859269a2b5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map.cs
+++ b/Assets/Scripts/Map.cs
@@ -58,9 +58,27 @@ public class Map : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.Space))
+        if (Input.GetKeyDown(KeyCode.A))
+        {
+            ShiftRowLeft(1);
+            Debug.Log("Width: " + Width + "\tHeight: " + Height);
+            Debug.Log(this);
+        }
+        if (Input.GetKeyDown(KeyCode.D))
         {
             ShiftRowRight(1);
+            Debug.Log("Width: " + Width + "\tHeight: " + Height);
+            Debug.Log(this);
+        }
+        if (Input.GetKeyDown(KeyCode.W))
+        {
+            ShiftColumnUp(1);
+            Debug.Log("Width: " + Width + "\tHeight: " + Height);
+            Debug.Log(this);
+        }
+        if (Input.GetKeyDown(KeyCode.S))
+        {
+            ShiftColumnDown(1);
             Debug.Log("Width: " + Width + "\tHeight: " + Height);
             Debug.Log(this);
         }
@@ -76,12 +94,79 @@ public class Map : MonoBehaviour
         }
         else
         {
-            // shift the tiles to the right of the current column into 
+            // shift the tile to the left of the current column into 
             // the current column, starting with the rightmost column
             for (int col = MapWidth - 1; col > 0; col--)
             {
                 LevelMap[row, col] = LevelMap[row, col - 1];
             }
+            LevelMap[row, 0] = null; // clear out leftmost tile leftover
+            UpdateDimensions();
+            return true;
+        }
+    }
+
+    private bool ShiftRowLeft(int row)
+    {
+        // if a tile is in the leftmost spot
+        if (LevelMap[row, 0] != null) 
+        {
+            Debug.LogError("Invalid shift, no buffer remaining.");
+            return false;
+        }
+        else
+        {
+            // shift the tile to the right of the current column into 
+            // the current column, starting with the leftmost column
+            for (int col = 0; col < MapWidth - 1; col++)
+            {
+                LevelMap[row, col] = LevelMap[row, col + 1];
+            }
+            LevelMap[row, MapWidth - 1] = null; // clear out rightmost tile leftover
+            UpdateDimensions();
+            return true;
+        }
+    }
+
+    private bool ShiftColumnDown(int col)
+    {
+        // if a tile is in the lowest spot
+        if (LevelMap[MapHeight - 1, col] != null) 
+        {
+            Debug.LogError("Invalid shift, no buffer remaining.");
+            return false;
+        }
+        else
+        {
+            // shift the tile above the current row into 
+            // the current row, starting with the bottom row
+            for (int row = MapHeight - 1; row > 0; row--)
+            {
+                LevelMap[row, col] = LevelMap[row - 1, col];
+            }
+            LevelMap[0, col] = null; // clear out highest tile leftover
+            UpdateDimensions();
+            return true;
+        }
+    }
+
+    private bool ShiftColumnUp(int col)
+    {
+        // if a tile is in the highest spot
+        if (LevelMap[0, col] != null) 
+        {
+            Debug.LogError("Invalid shift, no buffer remaining.");
+            return false;
+        }
+        else
+        {
+            // shift the tile below the current row into 
+            // the current row, starting with the top row
+            for (int row = 0; row < MapHeight - 1; row++)
+            {
+                LevelMap[row, col] = LevelMap[row + 1, col];
+            }
+            LevelMap[MapHeight - 1, col] = null; // clear out lowest tile leftover
             UpdateDimensions();
             return true;
         }

--- a/Assets/Scripts/Map.cs
+++ b/Assets/Scripts/Map.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Map : MonoBehaviour
+{
+    // 2D level array
+    private Tile[,] LevelMap;
+
+    // dimensions of the level and some info about how far it can be shifted
+    public int Width, Height, HorizontalBuffer, VerticalBuffer;
+
+    // list of units to be added to the level, made in the editor
+    private Dictionary<Point, Unit> Units;
+    public UnitsToAdd UnitsToAdd;
+
+    // empty tile prefab to load into map
+    public GameObject EmptyTilePrefab;
+
+    private void Start()
+    {
+        // stored in rows then columns
+        LevelMap = new Tile[Height + 2 * VerticalBuffer, Width + 2 * HorizontalBuffer];
+
+        // Load dictionary
+        Units = UnitsToAdd.BuildDictionary();
+
+        // generating tiles using empty tile prefab
+        for (int i = VerticalBuffer, y = 1; y <= Height; i++, y++) 
+        {
+            for (int j = HorizontalBuffer, x = 1; x <= Width; j++, x++) 
+            {
+                LevelMap[i, j] = Instantiate(EmptyTilePrefab).GetComponent<Tile>();
+                Unit unitToPlace;
+                if (Units.TryGetValue(new Point(x, y), out unitToPlace)) 
+                {
+                    LevelMap[i, j].SetUnit(unitToPlace);
+                    Debug.Log("Successfully added " + LevelMap[i, j].GetUnit() + " at (" + x + "," + y + ").");
+                }
+                else
+                {
+                    Debug.Log("Nothing found at (" + x + "," + y + ").");
+                }
+            }
+        }
+    }
+
+    private void Update()
+    {
+
+    }
+
+    private void ShiftRow()
+    {
+
+    }
+
+    private void ShiftColumn()
+    {
+
+    }
+}

--- a/Assets/Scripts/Map.cs.meta
+++ b/Assets/Scripts/Map.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8777f4488918d4e40a973994cf34ffea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Point.cs
+++ b/Assets/Scripts/Point.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class Point
+{
+    public int X, Y;
+
+    public Point(int x, int y) {
+        X = x;
+        Y = y;
+    }
+
+    public override int GetHashCode()
+    {
+        return X ^ Y;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is Point && (((Point) obj).X == X && ((Point) obj).Y == Y);
+    }
+}

--- a/Assets/Scripts/Point.cs.meta
+++ b/Assets/Scripts/Point.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 38c7af6828f2cb841bfde8310c278f32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class Tile : MonoBehaviour
 {
     private Sprite Texture;
-    public Unit Unit;
+    private Unit Unit;
 
     // update the unit stored in the current tile
     // returns if the new unit was successfully added to the tile

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Tile : MonoBehaviour
+{
+    private Sprite Texture;
+    public Unit Unit;
+
+    // update the unit stored in the current tile
+    // returns if the new unit was successfully added to the tile
+    public bool SetUnit(Unit unit)
+    {
+        if (Unit == null)
+        {
+            Unit = unit;
+            return true; // unit added successfully
+        }
+        else
+        {
+            return false; // cannot put two units on same tile
+        }
+    }
+
+    public Unit GetUnit() 
+    {
+        return Unit;
+    }
+}

--- a/Assets/Scripts/Tile.cs.meta
+++ b/Assets/Scripts/Tile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48b1727c0294b164cb4f5dee5a904e7c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Unit.cs
+++ b/Assets/Scripts/Unit.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Unit : MonoBehaviour
+{
+    public char Initial;
+    public char Player;
+
+    public override string ToString()
+    {
+        return "" + Initial + Player;
+    }
+
+    // this will be implemented later
+}

--- a/Assets/Scripts/Unit.cs.meta
+++ b/Assets/Scripts/Unit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2d0fe5ea84ce254e86f8e7810c49e79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UnitsToAdd.cs
+++ b/Assets/Scripts/UnitsToAdd.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class UnitsToAdd 
+{
+    public Unit[] Units;
+    public Point[] Points;
+
+    public Dictionary<Point, Unit> BuildDictionary()
+    {
+        Dictionary<Point, Unit> dictionary = new Dictionary<Point, Unit>();
+        for (int i = 0; i < Units.Length && i < Points.Length; i++) 
+        {
+            dictionary.Add(Points[i], Units[i]);
+        }
+        return dictionary;
+    }
+}

--- a/Assets/Scripts/UnitsToAdd.cs.meta
+++ b/Assets/Scripts/UnitsToAdd.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94f3011b7bb82d84f990eb41d52cf842
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Made the foundation for pulling the rows and columns of the map. The user can pull the second row with the A and D keys, and they can pull the second column with the W and S keys. For the time being, the map is displayed as text in the Debug console, and Units are represented by two characters.

Missing features:
* Selecting a row or column to pull
* Graphical display of map
* Graphical representation of tiles and players to be show on screen 
    * Note: their positions would be controlled by the map, not themselves
* Limitations on shifting buffer rows
    * The user should not be able to select these to be shifted, as they can be shifted infinitely
* Some method of storing selectable units for the player to select
* Pushing individual units